### PR TITLE
Fix rendering non-latin characters as HTML entities

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -12,5 +12,5 @@ export function appendUniversalPortals(html: string) {
     const markup = ReactDOMServer.renderToStaticMarkup(children);
     $(markup).attr("data-react-universal-portal", "").appendTo((selector as any))
   });
-  return $.html();
+  return $.html({ decodeEntities: false });
 }

--- a/tests/__snapshots__/server.spec.tsx.snap
+++ b/tests/__snapshots__/server.spec.tsx.snap
@@ -10,3 +10,14 @@ exports[`server-side appendUniversalPortals adds static mackup from portals to r
         
       <h1 data-react-universal-portal=\\"\\">Hello, World!</h1></body></html>"
 `;
+
+exports[`server-side appendUniversalPortals doesn't render non-latin characters as HTML entities 1`] = `
+"<html><head>
+            <meta charset=\\"utf-8\\">
+          <title data-react-universal-portal=\\"\\">Привет, мир!</title></head>
+          <body>
+            <div id=\\"root\\"></div>
+          
+        
+      <h1 data-react-universal-portal=\\"\\">Привет, мир!</h1></body></html>"
+`;

--- a/tests/server.spec.tsx
+++ b/tests/server.spec.tsx
@@ -27,5 +27,25 @@ describe("server-side", () => {
       expect(withStaticMarkup.includes("<h1>Hello, World!</h1>"));
       expect(withStaticMarkup).toMatchSnapshot();
     });
+
+    it("doesn't render non-latin characters as HTML entities", () => {
+      const html = `
+        <html>
+          <head>
+            <meta charset="utf-8" />
+          </head>
+          <body>
+            <div id="root"></div>
+          </body>
+        </html>
+      `;
+      createUniversalPortal(<title>Привет, мир!</title>, "head");
+      createUniversalPortal(<h1>Привет, мир!</h1>, "body");
+      const withStaticMarkup = appendUniversalPortals(html);
+
+      expect(withStaticMarkup.includes("<title>Привет, мир!</title>"));
+      expect(withStaticMarkup.includes("<h1>Привет, мир!</h1>"));
+      expect(withStaticMarkup).toMatchSnapshot();
+    });
   });
 });


### PR DESCRIPTION
By default cheerio encodes all non-latin characters into HTML entities which leads to bigger output and non-readable HTML code.

Since React renders this characters as regular unicode characters, I think react-portal-universal should have the same behavior.