### PR TITLE
Use ES5 target for build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2015",
+    "target": "ES5",
+    "lib": ["es2015", "dom"],
     "module": "commonjs",
     "jsx": "react",
     "strict": true,


### PR DESCRIPTION
Makes react-portal-universal compatible with IE10, Safari 9 and other React-compatible browsers that don't support `const`.